### PR TITLE
fix: prevent moving cursor inside a fold

### DIFF
--- a/autoload/EasyMotion.vim
+++ b/autoload/EasyMotion.vim
@@ -1303,7 +1303,7 @@ function! s:EasyMotion(regexp, direction, visualmode, is_inclusive, ...) " {{{
                 if search_direction ==# 'b'
                     " FIXME: Hmm... I should use filter()
                     " keepjumps call cursor(foldclosed(pos[0]), 0)
-                else
+                elseif foldclosedend(pos[0]+1) != -1
                     keepjumps call cursor(foldclosedend(pos[0]+1), 0)
                 endif
             else


### PR DESCRIPTION
See easymotion/vim-easymotion#484 for the background.

Fix: easymotion/vim-easymotion#383, Fix: easymotion/vim-easymotion#452
Close: easymotion/vim-easymotion#484
Co-authored-by: @Nealium